### PR TITLE
fix: add missing return in test_relay_getdata_rate_limit()

### DIFF
--- a/test/unit/test_relay.c
+++ b/test/unit/test_relay.c
@@ -358,6 +358,7 @@ static void test_relay_getdata_rate_limit(void) {
     test_fail("getdata should be rate limited");
     relay_destroy(mgr);
     free(peer);
+    return;
   }
 
   relay_destroy(mgr);


### PR DESCRIPTION
This one `return` slipped when fixing #4.