### PR TITLE
fix: missing return in test_relay_getdata_rate_limit()

### DIFF
--- a/test/unit/test_relay.c
+++ b/test/unit/test_relay.c
@@ -350,6 +350,7 @@ static void test_relay_getdata_rate_limit(void) {
       test_fail_int(message, (long)ECHO_SUCCESS, (long)result);
       relay_destroy(mgr);
       free(peer);
+      return;
     }
   }
 


### PR DESCRIPTION
## Summary
- Add missing `return` statement after test failure cleanup in rate limit test loop
- Prevents use-after-free if any loop iteration fails

## Problem
In `test_relay_getdata_rate_limit()`, when a test fails inside the loop, resources are freed but execution continues to the next iteration, causing use-after-free:

```c
for (size_t i = 0; i < MAX_GETDATA_PER_SECOND; i++) {
    if ((result = relay_handle_getdata(mgr, peer, &getdata)) != ECHO_SUCCESS) {
        test_fail_int(message, (long)ECHO_SUCCESS, (long)result);
        relay_destroy(mgr);
        free(peer);
        // MISSING: return; ← loop continues with freed pointers
    }
}
```

## Fix
Add `return;` after cleanup, matching the pattern used elsewhere in the same function (lines 357-362).

## Test plan
- [x] `make test/unit/test_relay` builds successfully
- [x] All 15 relay tests pass

Fixes #9