### PR TITLE
test: conform test_event_loop.c to testing guidelines

### DIFF
--- a/test/unit/test_event_loop.c
+++ b/test/unit/test_event_loop.c
@@ -16,7 +16,6 @@
 #include "mempool.h"
 #include "protocol.h"
 #include "sync.h"
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include "test_utils.h"


### PR DESCRIPTION
Fixes #19 
1. Remove unused PASS() macro
2. start using test_fai(), test_pass()
3. move test_case and test_pass() out of main()
